### PR TITLE
Fix GCC contract initialization and winner polling

### DIFF
--- a/erc20Abi.js
+++ b/erc20Abi.js
@@ -1,8 +1,15 @@
 // erc20Abi.js
+// Standard ERC-20 ABI used for GCC token interactions
 export default [
-  {"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":""}],"stateMutability":"view","type":"function"},
-  {"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":""}],"stateMutability":"nonpayable","type":"function"},
-  {"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":""}],"stateMutability":"view","type":"function"},
-  {"inputs":[{"internalType":"address","name":"recipient","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":""}],"stateMutability":"nonpayable","type":"function"},
-  {"inputs":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"address","name":"recipient","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":""}],"stateMutability":"nonpayable","type":"function"}
+  // Read functions
+  { "inputs": [], "name": "name", "outputs": [{ "internalType": "string", "name": "", "type": "string" }], "stateMutability": "view", "type": "function" },
+  { "inputs": [], "name": "symbol", "outputs": [{ "internalType": "string", "name": "", "type": "string" }], "stateMutability": "view", "type": "function" },
+  { "inputs": [], "name": "decimals", "outputs": [{ "internalType": "uint8", "name": "", "type": "uint8" }], "stateMutability": "view", "type": "function" },
+  { "inputs": [], "name": "totalSupply", "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }], "stateMutability": "view", "type": "function" },
+  { "inputs": [{ "internalType": "address", "name": "account", "type": "address" }], "name": "balanceOf", "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }], "stateMutability": "view", "type": "function" },
+  { "inputs": [{ "internalType": "address", "name": "owner", "type": "address" }, { "internalType": "address", "name": "spender", "type": "address" }], "name": "allowance", "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }], "stateMutability": "view", "type": "function" },
+  // Write functions
+  { "inputs": [{ "internalType": "address", "name": "spender", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" }], "name": "approve", "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }], "stateMutability": "nonpayable", "type": "function" },
+  { "inputs": [{ "internalType": "address", "name": "recipient", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" }], "name": "transfer", "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }], "stateMutability": "nonpayable", "type": "function" },
+  { "inputs": [{ "internalType": "address", "name": "sender", "type": "address" }, { "internalType": "address", "name": "recipient", "type": "address" }, { "internalType": "uint256", "name": "amount", "type": "uint256" }], "name": "transferFrom", "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }], "stateMutability": "nonpayable", "type": "function" }
 ];

--- a/winner.js
+++ b/winner.js
@@ -1,5 +1,5 @@
 // winner.js
-import { gameContract } from './frontendcore.js';
+import { gameRead } from './frontendcore.js';
 
 const $ = (id) => document.getElementById(id);
 const ZERO = '0x0000000000000000000000000000000000000000';
@@ -21,29 +21,29 @@ function setWinnerUI(addr, round) {
 
 // Fetch the last resolved round’s winner (no server storage needed)
 export async function refreshLastWinner() {
-  if (!gameContract) return;
+  if (!gameRead) return;
 
   // ethers v6 returns BigInt for uint256
-  const current = await gameContract.currentRound(); // BigInt
+  const current = await gameRead.currentRound(); // BigInt
   if (current === 0n) { setWinnerUI(null, 0); return; }
 
   // If a round is active, the “last” resolved one is current-1
-  const active = await gameContract.isRoundActive();
+  const active = await gameRead.isRoundActive();
   const lastRound = active ? (current - 1n) : current;
 
   if (lastRound <= 0n) { setWinnerUI(null, 0); return; }
 
   // Direct contract read — no logs, no server
-  const winner = await gameContract.winnerOfRound(lastRound);
+  const winner = await gameRead.winnerOfRound(lastRound);
   setWinnerUI(winner, lastRound);
 }
 
 // Live updates when a new round completes
 export function subscribeLastWinner() {
-  if (!gameContract) return;
+  if (!gameRead) return;
 
   // RoundCompleted(address winner, uint256 round)
-  gameContract.on('RoundCompleted', (winner, round) => {
+  gameRead.on('RoundCompleted', (winner, round) => {
     try {
       // round is BigInt in ethers v6
       setWinnerUI(winner, round);


### PR DESCRIPTION
## Summary
- replace ERC-20 ABI with standard functions and decimals
- add read/write GCC and game contract setup in frontend core
- use shared contract instances for balance checks and approvals
- poll and subscribe to last round winner without backend

## Testing
- `node --check frontendcore.js`
- `node --check freakyfriday.js`
- `node --check erc20Abi.js`
- `node --check winner.js`


------
https://chatgpt.com/codex/tasks/task_e_68a79f25282c832baedf462c0bdde3d4