### PR TITLE
Add unified join flow with auto approval and refund claim

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8"/>
+  <title>Freaky Friday</title>
+  <style>
+    .toast { padding: 10px 12px; margin-top: 10px; border-radius: 10px; }
+    .toast.info    { background:#eef5ff; }
+    .toast.success { background:#e8f9f1; }
+    .toast.error   { background:#ffecec; }
+    .note { font-size: 0.9em; color: #555; }
+  </style>
+</head>
+<body>
+  <button id="joinBtn">Join with 50 GCC</button>
+  <div class="note">If needed, we'll ask your wallet to approve GCC to the game first.</div>
+  <button id="claimBtn" disabled>Claim Refund</button>
+  <div>Winner: <span id="lastWinner">—</span></div>
+  <div>Prize: <span id="prize">—</span></div>
+  <div>Refund each: <span id="refund">—</span></div>
+  <div id="status"></div>
+
+  <script src="https://cdn.jsdelivr.net/npm/ethers@6.7.0/dist/ethers.umd.min.js"></script>
+  <script type="module">
+    import { unifiedJoin } from '../src/unified-join.js';
+    import gameAbi from '../src/abi/freakyFridayGameAbi.js';
+    import { FREAKY_CONTRACT } from '../src/frontendinfo.js';
+    const { ethers } = window;
+
+    document.getElementById('joinBtn').onclick = unifiedJoin;
+
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    const game = new ethers.Contract(FREAKY_CONTRACT, gameAbi, provider);
+    game.on('RoundCompleted', (winner, round, prizePaid, refundPerPlayerFinal) => {
+      document.getElementById('lastWinner').textContent = winner;
+      document.getElementById('prize').textContent  = `${ethers.formatUnits(prizePaid, 18)} GCC`;
+      document.getElementById('refund').textContent = `${ethers.formatUnits(refundPerPlayerFinal, 18)} GCC per player`;
+      window.currentClosedRound = Number(round);
+      document.getElementById('claimBtn')?.removeAttribute('disabled');
+    });
+
+    document.getElementById('claimBtn').onclick = async () => {
+      const signer = await provider.getSigner();
+      const gameW  = game.connect(signer);
+      const round = window.currentClosedRound;
+      if (!round && round !== 0) return;
+      const tx = await gameW.claimRefund(round);
+      const r  = await tx.wait();
+      const link = `https://bscscan.com/tx/${r?.hash || tx.hash}`;
+      document.getElementById('status').innerHTML =
+        `<div class="toast success">Refund claimed. <a href="${link}" target="_blank">View tx</a></div>`;
+    };
+  </script>
+</body>
+</html>

--- a/src/abi/freakyFridayGameAbi.js
+++ b/src/abi/freakyFridayGameAbi.js
@@ -1,0 +1,400 @@
+export default [
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_gcc",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "round",
+        "type": "uint256"
+      }
+    ],
+    "name": "Joined",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Received",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "winner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "round",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "prizePaid",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "refundPerPlayerFinal",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoundCompleted",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "admin",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "checkBNBBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "checkRewardBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "checkTimeExpired",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "currentRound",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "duration",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "enter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "entryAmount",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "fundBonus",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "gcc",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getContractTokenBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getParticipants",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "name": "hasJoinedThisRound",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isRoundActive",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxPlayers",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "name": "participants",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "relayedEnter",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "relayer",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "roundStart",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "setMaxPlayers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_relayer",
+        "type": "address"
+      }
+    ],
+    "name": "setRelayer",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address payable",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawBNB",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "to",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "withdrawLeftovers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "stateMutability": "payable",
+    "type": "receive"
+  }
+];

--- a/src/frontendinfo.js
+++ b/src/frontendinfo.js
@@ -1,0 +1,26 @@
+// frontendinfo.js
+//
+// This module defines constants for the Freaks2 front‑end.  Update these
+// values to point at your deployed contract, the GCC token and your
+// backend API.  These values are consumed by the core application code.
+
+// Address of the deployed FreakyFridayAuto contract (Freaks2).  Replace
+// this placeholder with your actual contract address after deployment.
+export const FREAKY_CONTRACT = '0x2608f724dec63dEa893BC5380FF0e77E5C446480';
+
+// Address of the GCC token contract on Binance Smart Chain.  Replace this
+// placeholder with the official GCC token address on mainnet.
+export const GCC_TOKEN = '0x092aC429b9c3450c9909433eB0662c3b7c13cF9A';
+
+// Address of your relayer wallet.  This constant is retained for
+// completeness, but note that approvals now target the game contract
+// directly.  You may still display the relayer address to users for
+// transparency or auditing purposes.
+export const FREAKY_RELAYER = '0xd5422b7493e65c5b5cbfd70028df2D2ED8A39CDE';
+
+// Base URL of the backend API.  The frontend will call relative paths on
+// this host (e.g. `${BACKEND_URL}/relay-entry`).  Update this to match
+// your deployed backend service (for local testing, use http://localhost:3000).
+export const BACKEND_URL = 'https://freak2backend.onrender.com';
+
+// No helper functions are defined here.  See freakyfriday.js for UI update logic.

--- a/src/unified-join.js
+++ b/src/unified-join.js
@@ -1,0 +1,85 @@
+// unified-join.js
+import { ethers } from "ethers";
+import gameAbi from "./abi/freakyFridayGameAbi.js";
+import { FREAKY_CONTRACT, GCC_TOKEN, BACKEND_URL } from "./frontendinfo.js";
+
+const erc20Abi = [
+  "function allowance(address owner, address spender) view returns (uint256)",
+  "function approve(address spender, uint256 amount) returns (bool)",
+  "function decimals() view returns (uint8)"
+];
+
+const BSC = {
+  chainId: "0x38",
+  chainName: "Binance Smart Chain",
+  nativeCurrency: { name: "BNB", symbol: "BNB", decimals: 18 },
+  rpcUrls: ["https://bsc-dataseed.binance.org/"],
+  blockExplorerUrls: ["https://bscscan.com/"],
+};
+
+function toast(msg, type = "info") {
+  const el = document.getElementById("status");
+  if (!el) return alert(msg);
+  el.innerHTML = `<div class="toast ${type}">${msg}</div>`;
+}
+
+async function ensureBSC(windowEth) {
+  const c = await windowEth.request({ method: "eth_chainId" });
+  if (c !== BSC.chainId) {
+    try {
+      await windowEth.request({ method: "wallet_switchEthereumChain", params: [{ chainId: BSC.chainId }] });
+    } catch (e) {
+      if (e?.code === 4902) {
+        await windowEth.request({ method: "wallet_addEthereumChain", params: [BSC] });
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+export async function unifiedJoin() {
+  try {
+    if (!window.ethereum) throw new Error("No wallet found");
+
+    // 1) Connect & ensure BSC
+    const provider = new ethers.BrowserProvider(window.ethereum);
+    await provider.send("eth_requestAccounts", []);
+    await ensureBSC(window.ethereum);
+
+    const signer = await provider.getSigner();
+    const user = await signer.getAddress();
+    const game = new ethers.Contract(FREAKY_CONTRACT, gameAbi, provider);
+
+    // 2) Read entry from chain (no magic numbers)
+    const entry = await game.entryAmount();
+
+    // 3) Auto-approve if needed (MAX to avoid repeated prompts)
+    const erc20 = new ethers.Contract(GCC_TOKEN, erc20Abi, signer);
+    const currentAllowance = await erc20.allowance(user, FREAKY_CONTRACT);
+    if (currentAllowance < entry) {
+      toast("Approving GCC for the game…", "info");
+      const approveTx = await erc20.approve(FREAKY_CONTRACT, ethers.MaxUint256);
+      await approveTx.wait();
+    }
+
+    // 4) Relay the join via backend
+    toast("Joining the ritual…", "info");
+    const resp = await fetch(`${BACKEND_URL}/join`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ user })
+    });
+    const json = await resp.json();
+    if (!resp.ok || !json?.success) throw new Error(json?.detail || json?.error || "Join failed");
+
+    const link = `https://bscscan.com/tx/${json.enterTxHash || json.txHash}`;
+    toast(
+      `🎉 You’ve joined! <a href="${link}" target="_blank" rel="noopener">View tx</a><br/>Refunds are paid after the round closes. Good luck!`,
+      "success"
+    );
+  } catch (err) {
+    const msg = err?.shortMessage || err?.message || String(err);
+    toast(`❌ ${msg}`, "error");
+  }
+}


### PR DESCRIPTION
## Summary
- add unified join module that auto-approves GCC and relays join through backend
- expose updated game ABI and constants under `src/`
- add minimal frontend wiring join, refund claim and event listener

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `node --check src/unified-join.js`
- `node --check src/frontendinfo.js`


------
https://chatgpt.com/codex/tasks/task_e_68a8138af884832b92ed4bc47dd086c7