### PR TITLE
feat: participants drawer with live tracking

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -314,3 +314,35 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 
 /* Optional: subtle grab cursor while dragging */
 .dock.grabbing, .dock-handle:active { cursor: grabbing; }
+
+/* Buttons & chips */
+.ff-btn{padding:.6rem .9rem;border-radius:12px;background:#1f8bff;color:#fff;border:0}
+.ff-btn:hover{filter:brightness(.95)}
+.ff-btn-secondary{padding:.55rem .85rem;border-radius:10px;background:#23262f;color:#e7e9ee;border:1px solid #343845}
+.ff-chip{margin-left:.4rem;background:#2a3040;color:#b9c2d0;padding:.1rem .45rem;border-radius:999px;font-size:.8rem}
+
+/* Friendlier 'Already joined' badge */
+.ff-joined-badge{display:inline-flex;align-items:center;gap:.4rem;background:#133621;border:1px solid #1b4b2c;
+  color:#a8f0c4;border-radius:999px;padding:.25rem .6rem;font-weight:600}
+
+/* Participants drawer (left) */
+.ff-drawer{position:fixed;inset:0 auto 0 0;width:min(92vw,420px);background:#0e1117;color:#e7e9ee;
+  transform:translateX(-100%);transition:transform .28s ease;z-index:60;display:flex;flex-direction:column;border-right:1px solid #1c2230}
+.ff-drawer.open{transform:translateX(0)}
+.ff-drawer-header{display:flex;align-items:center;justify-content:space-between;padding:14px 16px;border-bottom:1px solid #1c2230}
+.ff-icon-btn{background:transparent;border:0;color:#9aa5b1;font-size:1rem}
+.ff-icon-btn:hover{color:#fff}
+.ff-drawer-footer{padding:12px 16px;border-top:1px solid #1c2230}
+
+/* Overlay behind drawer */
+.ff-drawer-overlay{position:fixed;inset:0;background:rgba(0,0,0,.45);opacity:0;pointer-events:none;transition:opacity .25s ease;z-index:50}
+.ff-drawer-overlay.show{opacity:1;pointer-events:auto}
+
+/* Participant list */
+.ff-participants{padding:10px 8px 80px;overflow:auto;flex:1}
+.ff-row{display:flex;align-items:center;gap:10px;padding:10px;border-radius:12px;background:#121722;border:1px solid #1c2230;margin:6px 8px}
+.ff-ava{width:28px;height:28px;border-radius:8px;background:#20293a;display:grid;place-items:center;color:#9fb3ff;font-weight:700}
+.ff-addr{font-family:ui-monospace, SFMono-Regular, Menlo, monospace;font-size:.92rem;color:#dbe3f3;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1}
+.ff-badge{font-size:.72rem;background:#20324a;color:#9cc6ff;border:1px solid #2a3e5e;border-radius:999px;padding:.1rem .45rem}
+.ff-copy{background:#1e2430;border:1px solid #2c3546;color:#b7c1d8;border-radius:10px;padding:.25rem .5rem}
+.ff-copy:hover{background:#263146}

--- a/freakyfriday.js
+++ b/freakyfriday.js
@@ -162,7 +162,7 @@ async function connectMetaMask() {
     // Already joined?
     const parts = await gameContract.getParticipants();
     if (parts.map(a => a.toLowerCase()).includes(userAddress.toLowerCase())) {
-      setStatus('✅ Already joined this round');
+      setStatus('<span class="ff-joined-badge">✅ Already joined this round</span>');
       hide('approveBtn'); hide('joinBtn');
       // Still attach live winner listeners for UI updates.
       attachWinnerListenerLocal();

--- a/frontendcore.js
+++ b/frontendcore.js
@@ -10,7 +10,7 @@ export const byId = (id) => document.getElementById(id);
 
 export function setStatus(msg) {
   const statusEl = byId('status');
-  if (statusEl) statusEl.innerText = msg ?? '';
+  if (statusEl) statusEl.innerHTML = msg ?? '';
 }
 
 // ---- Runtime state (populated on connect) ----

--- a/index.html
+++ b/index.html
@@ -42,6 +42,28 @@
       <p class="subtext">A Weekly Ritual for Brave GCC Holders</p>
     </header>
 
+    <!-- Action to open drawer -->
+    <button id="ff-open-participants" class="ff-btn">
+      👥 Participants <span id="ff-participant-count" class="ff-chip">0</span>
+    </button>
+
+    <!-- Left off-canvas drawer -->
+    <aside id="ff-drawer" class="ff-drawer" aria-hidden="true">
+      <div class="ff-drawer-header">
+        <h3>Participants</h3>
+        <button id="ff-close-participants" class="ff-icon-btn" aria-label="Close">✖</button>
+      </div>
+
+      <div id="ff-participants-list" class="ff-participants"></div>
+
+      <div class="ff-drawer-footer">
+        <button id="ff-refresh-participants" class="ff-btn-secondary">Refresh</button>
+      </div>
+    </aside>
+
+    <!-- Dim overlay behind the drawer -->
+    <div id="ff-drawer-overlay" class="ff-drawer-overlay" aria-hidden="true"></div>
+
     <!-- Right dock controls -->
     <aside class="dock" role="region" aria-label="Join Freaky Friday">
       <div class="dock-inner">
@@ -88,12 +110,6 @@
       </div>
     </aside>
 
-    <!-- Participants rail -->
-    <section class="participants">
-      <h4>Players</h4>
-      <ul id="participantList"><li>Loading...</li></ul>
-    </section>
-
     <!-- optional: small invisible debug slot for contract/relayer -->
     <pre id="debug" style="display:none"></pre>
 
@@ -108,6 +124,7 @@
   <!-- Ethers + your app -->
   <script src="https://cdn.jsdelivr.net/npm/ethers@6.7.0/dist/ethers.umd.min.js"></script>
   <script type="module" src="./freakyfriday.js"></script>
+  <script type="module" src="./participants-drawer.js"></script>
   <script type="module">
   import { refreshLastWinner, subscribeLastWinner } from './winner.js';
   window.addEventListener('DOMContentLoaded', () => {

--- a/participants-drawer.js
+++ b/participants-drawer.js
@@ -1,0 +1,84 @@
+// participants-drawer.js
+import gameAbi from "./abi/freakyFridayGameAbi.js";
+import { FREAKY_CONTRACT } from "./frontendinfo.js";
+
+const el = (id) => document.getElementById(id);
+const short = (a) => (a ? `${a.slice(0,6)}…${a.slice(-4)}` : "");
+
+let provider, game, userAddr;
+
+export async function initParticipantsUI() {
+  provider = new ethers.BrowserProvider(window.ethereum);
+  game = new ethers.Contract(FREAKY_CONTRACT, gameAbi, provider);
+
+  try {
+    await provider.send("eth_requestAccounts", []);
+    const signer = await provider.getSigner();
+    userAddr = (await signer.getAddress()).toLowerCase();
+  } catch {/* guest view is fine */}
+
+  el("ff-open-participants").onclick  = openDrawer;
+  el("ff-close-participants").onclick = closeDrawer;
+  el("ff-drawer-overlay").onclick     = closeDrawer;
+  el("ff-refresh-participants").onclick = () => loadParticipants(true);
+
+  await loadParticipants(true);
+  game.on("Joined", async () => loadParticipants(false));
+}
+
+async function loadParticipants(updateCount) {
+  try {
+    const list = await game.getParticipants(); // address[]
+    renderList(list);
+    if (updateCount) el("ff-participant-count").textContent = list.length ?? 0;
+  } catch (e) { console.warn("loadParticipants failed", e); }
+}
+
+function renderList(list) {
+  const wrap = el("ff-participants-list");
+  wrap.innerHTML = "";
+  if (!list || !list.length) {
+    wrap.innerHTML = `<div class="ff-row">No one has joined yet. Be the first!</div>`;
+    el("ff-participant-count").textContent = 0;
+    return;
+  }
+  el("ff-participant-count").textContent = list.length;
+
+  list.forEach((addr) => {
+    const a = addr.toLowerCase();
+    const row = document.createElement("div");
+    row.className = "ff-row";
+    row.innerHTML = `
+      <div class="ff-ava">${short(a).slice(2,3).toUpperCase()}</div>
+      <div class="ff-addr">${a}</div>
+      ${userAddr && a === userAddr ? `<span class="ff-badge">You</span>` : ""}
+      <button class="ff-copy" data-addr="${a}" aria-label="Copy address">Copy</button>
+    `;
+    wrap.appendChild(row);
+  });
+
+  wrap.querySelectorAll(".ff-copy").forEach(btn => {
+    btn.addEventListener("click", async (e) => {
+      const a = e.currentTarget.getAttribute("data-addr");
+      try {
+        await navigator.clipboard.writeText(a);
+        e.currentTarget.textContent = "Copied";
+        setTimeout(() => (e.currentTarget.textContent = "Copy"), 1000);
+      } catch {}
+    });
+  });
+}
+
+function openDrawer() {
+  el("ff-drawer").classList.add("open");
+  el("ff-drawer-overlay").classList.add("show");
+  el("ff-drawer").setAttribute("aria-hidden", "false");
+}
+function closeDrawer() {
+  el("ff-drawer").classList.remove("open");
+  el("ff-drawer-overlay").classList.remove("show");
+  el("ff-drawer").setAttribute("aria-hidden", "true");
+}
+
+if (document.readyState !== "loading") initParticipantsUI();
+else document.addEventListener("DOMContentLoaded", initParticipantsUI);


### PR DESCRIPTION
## Summary
- add participant drawer with live count, copy button and You badge
- style joined status with friendly green badge
- expose participants drawer module and styles

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check participants-drawer.js`
- `node --check freakyfriday.js`


------
https://chatgpt.com/codex/tasks/task_e_68a81d5a4cb0832bb43bb3f45b2161bf