### PR TITLE
Wire bottom connect button and MetaMask deeplink

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -427,3 +427,13 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 @media (max-height: 640px) {
   .hero, .intro, .actions { margin-block-end: 8px; }
 }
+
+.connect-bottom {
+  margin: 18px 0 24px;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+.deeplink.hidden { display: none; }

--- a/frontendinfo.js
+++ b/frontendinfo.js
@@ -3,7 +3,7 @@
 // This module defines constants for the Freaks2 front‑end.  Update these
 // values to point at your deployed contract, the GCC token and your
 // backend API.  These values are consumed by the core application code.
-
+//
 // Address of the deployed FreakyFridayAuto contract (Freaks2).  Replace
 // this placeholder with your actual contract address after deployment.
 export const FREAKY_CONTRACT = '0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9';

--- a/index.html
+++ b/index.html
@@ -110,9 +110,12 @@
 
     <!-- optional: small invisible debug slot for contract/relayer -->
     <pre id="debug" style="display:none"></pre>
-
-   
-
+    <section class="connect-bottom">
+      <button id="connectBtnBottom" class="secondary">🔗 Connect Wallet</button>
+      <a id="deeplinkBottom" class="deeplink hidden" href="#" rel="noopener">
+        📱 Open in MetaMask (mobile)
+      </a>
+    </section>
 
     <footer class="footer">
       <p class="footer-note flicker">Built by the Condor Crew. Powered by GCC. Fueled by ritual.</p>
@@ -387,6 +390,8 @@
 
 })();
 </script>
+
+<script type="module" src="./wallet-wiring.js"></script>
 
 </body>
 </html>

--- a/wallet-wiring.js
+++ b/wallet-wiring.js
@@ -1,0 +1,52 @@
+// wallet-wiring.js
+const FRONTEND_HOST = window.location.host; // works on Render & localhost
+const METAMASK_DAPP = `https://metamask.app.link/dapp/${FRONTEND_HOST}/`;
+
+const hasEthereum = () => typeof window.ethereum !== 'undefined';
+const isAndroid   = () => /Android/i.test(navigator.userAgent);
+const isInApp     = () =>
+  /(FBAN|FBAV|Instagram|Line|Twitter|OkHttp|Telegram)/i.test(navigator.userAgent || '');
+
+function wireConnect(buttonId) {
+  const btn = document.getElementById(buttonId);
+  if (!btn) return;
+  btn.addEventListener('click', async () => {
+    try {
+      // On Android with no provider or inside in-app browser, deep-link to MetaMask dApp browser.
+      if (isAndroid() && (!hasEthereum() || isInApp())) {
+        window.location.href = METAMASK_DAPP;
+        return;
+      }
+      if (!hasEthereum()) {
+        // Non-Android fallback: click the top deeplink if present
+        const a = document.getElementById('deeplink');
+        if (a) a.click();
+        return;
+      }
+      await window.ethereum.request({ method: 'eth_requestAccounts' });
+      // Success: your existing app code (freakyfriday.js) should detect the connection and update UI.
+    } catch (e) {
+      console.warn('Connect cancelled/failed', e);
+    }
+  });
+}
+
+function exposeDeepLink(anchorId) {
+  const a = document.getElementById(anchorId);
+  if (!a) return;
+  const shouldShow = isAndroid() && (!hasEthereum() || isInApp());
+  if (shouldShow) {
+    a.href = METAMASK_DAPP;
+    a.classList.remove('hidden');
+  } else {
+    a.classList.add('hidden');
+  }
+}
+
+// Wire both connect CTAs
+wireConnect('connectBtn');         // top button (already working)
+wireConnect('connectBtnBottom');   // lower button (needs wiring)
+
+// Show green deeplinks when relevant
+exposeDeepLink('deeplink');        // top deeplink (already in DOM)
+exposeDeepLink('deeplinkBottom');  // bottom deeplink (new)


### PR DESCRIPTION
## Summary
- Add bottom connect button with optional MetaMask deep-link
- Expose Android MetaMask deep-link and wire both connect buttons
- Clean up frontend constants file formatting and styles for new connect section

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8cf06927c832baf8b5f61dfebaf38