### PR TITLE
fix: update contract address and timer

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,7 +90,7 @@
           <div class="ff-timer">
             <div class="ff-timer-row">
               <span id="ff-time-label">Round ends in:</span>
-              <span id="countdown">—</span>
+              <span id="countdown">00:00</span>
             </div>
             <div class="ff-progress">
               <div id="ff-progress-bar"></div>

--- a/src/frontendinfo.js
+++ b/src/frontendinfo.js
@@ -6,7 +6,7 @@
 
 // Address of the deployed FreakyFridayAuto contract (Freaks2).  Replace
 // this placeholder with your actual contract address after deployment.
-export const FREAKY_CONTRACT = '0x2608f724dec63dEa893BC5380FF0e77E5C446480';
+export const FREAKY_CONTRACT = '0x2a37F0325bcA2B71cF7f2189796Fb9BC1dEBc9C9';
 
 // Address of the GCC token contract on Binance Smart Chain.  Replace this
 // placeholder with the official GCC token address on mainnet.


### PR DESCRIPTION
## Summary
- point frontend to updated Freaks2 contract
- align countdown span ID and default display

## Testing
- `node -e "const fs=require('fs');const parse=p=>eval(fs.readFileSync(p,'utf8').replace('export default',''));['src/abi/freakyFridayGameAbi.js','abi/freakyFridayGameAbi.js'].forEach(p=>{const abi=parse(p);console.log(p,abi.some(f=>f.name==='isRoundActive'),abi.some(f=>f.name==='checkTimeExpired'),abi.some(f=>f.name==='getParticipants'))});"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a97faa5a94832b882036f33c759327