### PR TITLE
feat: add admin mode switch and jackpot theme

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -541,49 +541,75 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 .rules__link{ color:#71e0a9; text-decoration: underline; }
 #rulesClose{ background:transparent; color:#fff; border:none; font-size:1.2rem; }
 
-/* Admin toggle switch */
-.mode-toolbar {
-  display:flex; align-items:center; gap:.75rem; margin:.5rem 0;
-}
-.mode-badge {
-  display:inline-block; padding:.25rem .5rem; border-radius:6px;
-  background:#222; color:#fff; font-weight:600; font-size:.9rem;
-}
-.admin-toggle.hidden { display:none; }
-
-.switch { position:relative; display:inline-block; width:52px; height:28px; }
-.switch input { opacity:0; width:0; height:0; }
-.slider {
-  position:absolute; cursor:pointer; top:0; left:0; right:0; bottom:0;
-  background:#bbb; transition:.2s; border-radius:28px;
-}
-.slider:before {
-  position:absolute; content:""; height:22px; width:22px; left:3px; bottom:3px;
-  background:white; transition:.2s; border-radius:50%;
-}
-input:checked + .slider { background:#7b00ff; }
-input:checked + .slider:before { transform:translateX(24px); }
-
-/* Freaky site-wide theme toggled on <body class="freaky"> */
-body.freaky {
+/* Freaky site-wide theme toggled on <body class="freaky-mode"> */
+body.freaky-mode {
   --brand-bg: #0a0014;
   --brand-accent: #7b00ff;
   --brand-accent-2: #e4007c;
   background: radial-gradient(1200px 800px at 50% -20%, #1c0038, #0a0014 60%);
   color: #f5f0ff;
 }
-body.freaky .mode-badge { background: linear-gradient(90deg, #7b00ff, #e4007c); }
-body.freaky .button, body.freaky button {
+body.freaky-mode .mode-badge { background: linear-gradient(90deg, #7b00ff, #e4007c); }
+body.freaky-mode .button, body.freaky-mode button {
   border-color:#7b00ff; color:#fff; background:#1c0038;
 }
-body.freaky a { color:#e6b3ff; }
+body.freaky-mode a { color:#e6b3ff; }
 
 @media (prefers-reduced-motion: no-preference) {
-  body.freaky {
+  body.freaky-mode {
     animation: subtlePulse 8s ease-in-out infinite;
   }
   @keyframes subtlePulse {
     0%,100% { filter:saturate(1); }
     50%     { filter:saturate(1.15); }
   }
+}
+
+/* Mode badge */
+.mode-badge {
+  display:inline-block;
+  padding: .25rem .5rem;
+  border-radius: .5rem;
+  font-weight: 600;
+  background: #ececec;
+  color: #333;
+}
+
+/* Admin panel */
+.admin-panel {
+  margin-top: 1rem;
+  padding: .75rem;
+  border: 1px solid #ddd;
+  border-radius: .5rem;
+  background: #fafafa;
+}
+.admin-actions { display:flex; gap:.5rem; }
+.btn-admin {
+  padding: .5rem .75rem;
+  border: 1px solid #999;
+  border-radius: .4rem;
+  background: #fff;
+  font-weight: 600;
+  cursor: pointer;
+}
+.btn-admin:disabled { opacity: .5; cursor: not-allowed; }
+.btn-admin.danger { border-color:#9b1c31; color:#9b1c31; }
+
+/* Freaky theme */
+body.freaky-mode {
+  background: radial-gradient(1200px 600px at 50% -10%, #2a002e 0%, #0f0011 60%, #050007 100%);
+  color: #f3f2f4;
+}
+body.freaky-mode .mode-badge {
+  background: #2c0a2f;
+  color: #f7d1f7;
+  box-shadow: 0 0 12px rgba(251, 98, 255, .4);
+}
+body.freaky-mode .btn-admin {
+  border-color: #f06;
+  color: #f7d1f7;
+}
+body.freaky-mode .btn-admin.danger {
+  background: #3a003f;
+  border-color: #ff4db3;
 }

--- a/index.html
+++ b/index.html
@@ -25,18 +25,18 @@
     <button id="openInMMTop" class="deeplink-btn">Open in MetaMask (mobile)</button>
   </div>
 
-  <div class="mode-toolbar">
-    <span id="modeBadge" class="mode-badge">—</span>
+  <!-- Mode Badge -->
+  <div id="modeBadge" class="mode-badge">—</div>
 
-    <!-- Hidden for non-admins; shown for admin/relayer -->
-    <div id="adminModeToggle" class="admin-toggle hidden">
-      <label class="switch">
-        <input type="checkbox" id="freakySwitch">
-        <span class="slider"></span>
-      </label>
-      <span id="freakySwitchLabel">Standard</span>
+  <!-- Admin Panel (hidden by default) -->
+  <section id="adminPanel" class="admin-panel" style="display:none;">
+    <h3>Admin Controls</h3>
+    <div class="admin-actions">
+      <button id="btnModeStandard" class="btn-admin">Switch to Standard</button>
+      <button id="btnModeJackpot" class="btn-admin danger">Switch to Jackpot</button>
     </div>
-  </div>
+    <div id="adminStatus" class="admin-status"></div>
+  </section>
 
   <main class="stage">
     <!-- Big scary poster -->


### PR DESCRIPTION
## Summary
- add mode badge and admin panel gated to admin/relayer
- apply mode-aware theming with freaky-mode class
- wire contract mode controls into frontend

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4ff8d9cc832bb3c2856819527651