### PR TITLE
feat: add admin round control and state UI

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -198,6 +198,9 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 .dock-inner { padding: 14px 16px; height: 100%; overflow: auto; }
 .deeplink { color: #00ff88; font-weight: 700; }
 
+.round-state { margin:.5rem 0; opacity:.9; }
+.btn-join[disabled] { opacity:.5; cursor:not-allowed; }
+
 /* Sticky bottom connect button */
 .connect-sticky {
   position: sticky; /* sits just above the bottom safe area */

--- a/index.html
+++ b/index.html
@@ -38,6 +38,16 @@
     <div id="adminStatus" class="admin-status"></div>
   </section>
 
+  <div id="roundState" class="round-state">—</div>
+
+  <section id="adminArmPanel" class="admin-panel" style="display:none;">
+    <h3>Admin Controls</h3>
+    <div class="admin-actions">
+      <button id="btnArmRound" class="btn-admin">Open New Round</button>
+    </div>
+    <div id="adminArmStatus" class="admin-status"></div>
+  </section>
+
   <main class="stage">
     <!-- Big scary poster -->
     <figure class="poster" aria-hidden="true">
@@ -73,7 +83,7 @@
 
         <button id="connectBtn">🔗 Connect Wallet</button>
         <button id="approveBtn" disabled>✅ Step 1: Approve 50 GCC to Contract</button>
-        <button id="joinBtn" disabled>🚀 Step 2: Join the Ritual</button>
+        <button id="joinBtn" class="btn-join" disabled>🚀 Step 2: Join the Ritual</button>
 
         <div id="status" class="status" role="status">⏳ Waiting for wallet connection...</div>
         <p>Wallet: <span id="walletAddress">—</span></p>
@@ -95,7 +105,7 @@
           <span id="ff-joined-badge" class="ff-joined-badge" style="display:none">✅ Already joined this round</span>
 
           <!-- Timer + progress bar -->
-          <div class="ff-timer">
+          <div id="timerContainer" class="ff-timer">
             <div class="ff-timer-row">
               <span id="ff-time-label">Round ends in:</span>
               <span id="countdown">00:00</span>


### PR DESCRIPTION
## Summary
- show round status and disable join when round inactive
- allow admins to open a new round via relayed self-entry
- style join button and round state for clearer UX

## Testing
- `node --version`
- `node --check freakyfriday.js`
- `node --check round-timer.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa86cfc550832bb102ef9bdbd80626