### PR TITLE
feat: add one-click join flow

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -199,7 +199,6 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 .deeplink { color: #00ff88; font-weight: 700; }
 
 .round-state { margin:.5rem 0; opacity:.9; }
-.btn-join[disabled] { opacity:.5; cursor:not-allowed; }
 
 /* Sticky bottom connect button */
 .connect-sticky {
@@ -289,7 +288,7 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 /* Spinner (basic) */
 #loader { position: fixed; inset: 0; display: grid; place-items: center; background: rgba(0,0,0,.45); z-index: 9; }
 #loader.hidden { display: none !important; pointer-events: none !important; opacity: 0 !important; }
-.spinner { width: 44px; height: 44px; border-radius: 50%; border: 3px solid rgba(255,255,255,.25); border-top-color: #fff; animation: spin 1s linear infinite; }
+.spinner { width:54px;height:54px;border-radius:50%;border:6px solid #ffffff66;border-top-color:#fff;animation:spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
 /* ============== Dynamic Poster FX ============== */
@@ -627,3 +626,13 @@ body.freaky-mode .btn-admin.danger {
   background: #3a003f;
   border-color: #ff4db3;
 }
+
+/* One-click join helpers */
+.overlay{
+  position:fixed; inset:0; display:flex; align-items:center; justify-content:center;
+  background:rgba(0,0,0,.55); z-index:9999; backdrop-filter: blur(2px);
+}
+.error{ color:#ff6b6b; margin-top:.4rem; }
+.muted{ color:#cfcfd6; margin-top:.25rem; }
+.tiny-link{ font-size:.85rem; opacity:.8; display:inline-block; margin-top:.5rem; }
+.btn.primary:disabled{ opacity:.6; cursor:not-allowed; }

--- a/index.html
+++ b/index.html
@@ -21,6 +21,12 @@
   <!-- Spinner (optional, your existing JS toggles .hidden) -->
   <div id="loader" class="hidden"><div class="spinner"></div></div>
 
+  <!-- Spinner Overlay -->
+  <div id="overlay" class="overlay" style="display:none;">
+    <div class="spinner"></div>
+    <div id="overlayMsg">Working…</div>
+  </div>
+
   <div class="mobile-open-bar">
     <button id="openInMMTop" class="deeplink-btn">Open in MetaMask (mobile)</button>
   </div>
@@ -95,9 +101,16 @@
         </p>
 
         <button id="connectBtn">🔗 Connect Wallet</button>
-        <button id="approveBtn" disabled>✅ Step 1: Approve 50 GCC to Contract</button>
-        <button id="joinBtn" class="btn-join" disabled>🚀 Step 2: Join the Ritual</button>
-        <div id="step2Error" class="status" style="display:none"></div>
+        <div id="step2">
+          <button id="joinBtn" class="btn primary" disabled>Join the Ritual</button>
+          <div id="step2Msg" class="muted"></div>
+          <div id="step2Error" class="error"></div>
+          <a id="advancedLink" class="tiny-link">Advanced: use separate steps</a>
+          <div id="advancedPanel" style="display:none;">
+            <button id="approveBtn" class="btn">Approve</button>
+            <button id="enterBtn" class="btn">Join (manual)</button>
+          </div>
+        </div>
 
         <div id="status" class="status" role="status">⏳ Waiting for wallet connection...</div>
         <p>Wallet: <span id="walletAddress">—</span></p>


### PR DESCRIPTION
## Summary
- replace two-step UI with single Join the Ritual button and advanced manual panel
- add overlay spinner, status messaging, and auto-approve/join logic
- include overlay/disabled styles and robust error handling

## Testing
- `node --check freakyfriday.js`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac7a1d528832b9f30776bee47f8d6