### PR TITLE
feat: add reliable admin round opening

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -604,6 +604,11 @@ body.freaky-mode a { color:#e6b3ff; }
 }
 .btn-admin:disabled { opacity: .5; cursor: not-allowed; }
 .btn-admin.danger { border-color:#9b1c31; color:#9b1c31; }
+.btn-admin.loading { opacity:.6; cursor:wait; }
+.admin-open-row { display:flex; gap:.5rem; align-items:center; }
+.admin-hint { margin:.25rem 0 .5rem; color:#333; }
+.admin-status { margin-left:.5rem; font-weight:600; }
+.admin-mini { margin-top:.5rem; font-size:.9rem; color:#555; }
 .admin-card { border:1px solid #ddd; border-radius:.5rem; padding:.75rem; margin:.75rem 0; background:#fafafa; }
 .admin-card-header { font-weight:700; margin-bottom:.5rem; }
 .sr-only { position:absolute; left:-9999px; }

--- a/freakyfriday.js
+++ b/freakyfriday.js
@@ -7,6 +7,7 @@
 // - Chain guard for BSC mainnet (56)
 // - Mobile deep link helper & robust UI handling
 
+import abi from './freakyFridayGameAbi.js';
 import { FREAKY_CONTRACT, GCC_TOKEN, FREAKY_RELAYER } from './frontendinfo.js';
 import { connectWallet as coreConnectWallet, provider, gameContract, gccRead, gccWrite, userAddress as connectedAddr, gameRead, signer } from './frontendcore.js';
 import { mountLastWinner } from './winner.js';
@@ -273,23 +274,119 @@ async function refreshRoundState(game) {
 
 async function showAdminArmIfAuthorized(game, me, relayerAddr) {
   const isAdmin = await isAdminOrRelayer(game, me, relayerAddr);
-  const panel = document.getElementById('adminArmPanel');
-  if (panel) panel.style.display = isAdmin ? 'block' : 'none';
-  return isAdmin;
+  if (!isAdmin) {
+    const panel = document.getElementById('adminOpenWrap');
+    if (panel) panel.style.display = 'none';
+    return false;
+  }
+  await initAdminOpenFlow(provider, signer, game);
+  return true;
 }
 
-function setArmStatus(msg) {
-  const el = document.getElementById('adminArmStatus');
+function shortErr(e) {
+  return (e?.shortMessage || e?.reason || e?.message || 'Unknown error');
+}
+
+async function getTokenContract(game, signer) {
+  const gccAddr = await game.gcc();
+  const erc20Abi = [
+    "function balanceOf(address) view returns (uint256)",
+    "function allowance(address,address) view returns (uint256)",
+    "function approve(address,uint256) returns (bool)"
+  ];
+  return new ethers.Contract(gccAddr, erc20Abi, signer);
+}
+
+async function refreshAdminOpenUI(provider, signer, game) {
+  const me = await signer.getAddress();
+  const inactive = !(await game.isRoundActive());
+  const wrap = document.getElementById('adminOpenWrap');
+  if (wrap) wrap.style.display = inactive ? 'block' : 'none';
+  if (!inactive) return;
+
+  const gcc = await getTokenContract(game, signer);
+  const need = await game.entryAmount();
+  const bal = await gcc.balanceOf(me);
+  const alw = await gcc.allowance(me, FREAKY_CONTRACT);
+
+  const balEl = document.getElementById('relayerBalance');
+  const alwEl = document.getElementById('relayerAllowance');
+  if (balEl) balEl.textContent = `Relayer GCC balance: ${ethers.formatUnits(bal, 18)}`;
+  if (alwEl) alwEl.textContent = `Allowance to game: ${ethers.formatUnits(alw, 18)}`;
+
+  const canOpen = alw >= need && bal >= need;
+  const btnApprove = document.getElementById('btnApproveGCC');
+  const btnOpen = document.getElementById('btnOpenRound');
+  if (btnApprove) btnApprove.style.display = canOpen ? 'none' : 'inline-block';
+  if (btnOpen) btnOpen.disabled = !canOpen;
+  const hint = document.getElementById('adminOpenState');
+  if (hint) hint.textContent = 'Round inactive — ready to open' + (canOpen ? '' : ' (approve needed)');
+}
+
+function setOpenStatus(msg) {
+  const el = document.getElementById('openStatus');
   if (el) el.textContent = msg || '';
 }
 
-async function armRound(game, me) {
-  const tx = await game.relayedEnter(me);
-  setArmStatus(`Arming… tx: ${tx.hash}`);
-  await tx.wait();
-  setArmStatus('✅ New round opened');
-  await refreshRoundState(game);
-  await maybeShowTimer(game);
+function setLoading(buttons, on) {
+  buttons.forEach(b => {
+    if (!b) return;
+    b.disabled = !!on;
+    b.classList.toggle('loading', !!on);
+  });
+}
+
+export async function initAdminOpenFlow(provider, signer, game) {
+  const btnOpen = document.getElementById('btnOpenRound');
+  const btnApprove = document.getElementById('btnApproveGCC');
+  if (!btnOpen || btnOpen.dataset.wired === '1') {
+    await refreshAdminOpenUI(provider, signer, game);
+    return;
+  }
+  btnOpen.dataset.wired = '1';
+  if (btnApprove) btnApprove.dataset.wired = '1';
+
+  await refreshAdminOpenUI(provider, signer, game);
+
+  btnApprove?.addEventListener('click', async () => {
+    try {
+      setOpenStatus('Approving GCC…');
+      setLoading([btnOpen, btnApprove], true);
+      const gcc = await getTokenContract(game, signer);
+      const need = await game.entryAmount();
+      const tx = await gcc.approve(FREAKY_CONTRACT, need);
+      setOpenStatus(`Approve sent: ${tx.hash.slice(0,10)}…`);
+      await tx.wait();
+      setOpenStatus('Approve mined ✔');
+      await refreshAdminOpenUI(provider, signer, game);
+    } catch (e) {
+      console.error('approve failed', e);
+      setOpenStatus('❌ Approve failed — ' + shortErr(e));
+    } finally {
+      setLoading([btnOpen, btnApprove], false);
+    }
+  });
+
+  btnOpen?.addEventListener('click', async () => {
+    try {
+      setOpenStatus('Opening…');
+      setLoading([btnOpen, btnApprove], true);
+      const me = await signer.getAddress();
+      const tx = await game.relayedEnter(me);
+      setOpenStatus(`Open tx: ${tx.hash.slice(0,10)}…`);
+      await tx.wait();
+      setOpenStatus('Round opened ✔');
+      await refreshAdminOpenUI(provider, signer, game);
+      await refreshRoundState(game);
+      await maybeShowTimer(game);
+    } catch (e) {
+      console.error('open failed', e);
+      setOpenStatus('❌ Failed to open — ' + shortErr(e));
+      await refreshAdminOpenUI(provider, signer, game);
+    } finally {
+      setLoading([btnOpen, btnApprove], false);
+    }
+  });
 }
 
 async function getLastResolvedRound(g) {
@@ -517,7 +614,12 @@ export async function connectWallet() {
       await refreshRoundState(gameContract);
       await maybeShowTimer(gameContract);
       gameContract.on('Joined', () => maybeShowTimer(gameContract));
-      gameContract.on('RoundCompleted', () => maybeShowTimer(gameContract));
+      gameContract.on('RoundCompleted', async () => {
+        await maybeShowTimer(gameContract);
+        await refreshRoundState(gameContract);
+        const a = (await signer.getAddress?.().catch(() => null)) || connectedAddr;
+        await showAdminArmIfAuthorized(gameContract, a, FREAKY_RELAYER);
+      });
       const isAdmin = await showAdminArmIfAuthorized(
         gameContract,
         userAddress,
@@ -532,7 +634,6 @@ export async function connectWallet() {
     if (isAdmin) {
       const btnStd = document.getElementById('btnModeStandard');
       const btnJp  = document.getElementById('btnModeJackpot');
-      const armBtn = document.getElementById('btnArmRound');
 
       btnStd?.addEventListener('click', async () => {
         try {
@@ -574,19 +675,6 @@ export async function connectWallet() {
         }
       });
 
-      armBtn?.addEventListener('click', async () => {
-        try {
-          const active = await gameContract.isRoundActive();
-          if (active) { setArmStatus('Already active.'); return; }
-          armBtn.disabled = true;
-          await armRound(gameContract, userAddress);
-        } catch (e) {
-          console.error(e);
-          setArmStatus('❌ Failed to open (check GCC balance/allowance).');
-        } finally {
-          armBtn.disabled = false;
-        }
-      });
     }
 
     await refreshLastRound();

--- a/index.html
+++ b/index.html
@@ -53,12 +53,20 @@
 
   <div id="roundState" class="round-state">—</div>
 
-  <section id="adminArmPanel" class="admin-panel" style="display:none;">
+  <section id="adminOpenWrap" class="admin-panel">
     <h3>Admin Controls</h3>
-    <div class="admin-actions">
-      <button id="btnArmRound" class="btn-admin">Open New Round</button>
+    <div id="adminOpenState" class="admin-hint">Round inactive — waiting to open</div>
+
+    <div class="admin-open-row">
+      <button id="btnOpenRound" class="btn-admin">Open New Round</button>
+      <button id="btnApproveGCC" class="btn-admin" style="display:none;">Approve GCC</button>
+      <span id="openStatus" class="admin-status"></span>
     </div>
-    <div id="adminArmStatus" class="admin-status"></div>
+
+    <div class="admin-mini">
+      <span id="relayerBalance">—</span>
+      <span id="relayerAllowance">—</span>
+    </div>
   </section>
 
   <main class="stage">


### PR DESCRIPTION
## Summary
- add admin open round panel with balance/allowance display and GCC approval
- wire admin open flow to handle approvals, opening and error messages
- add helper styles for admin panel and loading state

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1eadce90832b9ba5a20ca870557a