### PR TITLE
feat: add last round drawer

### DIFF
--- a/freakyfriday.css
+++ b/freakyfriday.css
@@ -320,35 +320,75 @@ button:hover:not(:disabled), button:focus-visible:not(:disabled) {
 .spinner { width:54px;height:54px;border-radius:50%;border:6px solid #ffffff66;border-top-color:#fff;animation:spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
 
-/* Last Round pull-out panel */
-.last-round {
-  position: fixed; right: 12px; bottom: 92px; z-index: 40;
-  color: #111; background: #fff; border: 1px solid #e3e3e3; border-radius: 10px;
-  box-shadow: 0 10px 24px rgba(0,0,0,.15);
-  width: min(92vw, 560px);
+/* Drawer shell */
+.drawer {
+  position: fixed;
+  top: 0;
+  right: -360px;                 /* hidden */
+  width: 320px;                  /* narrow so it never covers timer */
+  height: 100vh;
+  background: #121113;           /* dark panel for contrast */
+  color: #f5f5f7;
+  box-shadow: -8px 0 24px rgba(0,0,0,.45);
+  border-left: 1px solid rgba(255,255,255,.08);
+  transition: right .28s ease;
+  z-index: 60;                   /* below wallet modals if they use 100+ */
+  display: flex; flex-direction: column;
 }
-.last-round.hidden { display: none; }
+.drawer.open { right: 0; }
 
-.last-round__toggle {
-  width: 100%; text-align: left; padding: .6rem .8rem; font-weight: 700;
-  background: #fafafa; border: 0; border-bottom: 1px solid #eee; cursor: pointer;
+.drawer-title {
+  margin: 14px 16px 8px;
+  font-weight: 700;
 }
-.last-round__body { padding: .7rem .9rem; }
-.lr-row { display: flex; flex-wrap: wrap; gap: .5rem; align-items: baseline; margin: .25rem 0; }
-.lr-row code { background: #f5f5f7; border: 1px solid #eee; padding: 0 .33rem; border-radius: 4px; }
-.lr-sep { opacity: .65; }
-.lr-msg { margin-top: .5rem; font-size: .92rem; color: #b00020; }
+
+.drawer-body { padding: 0 16px 16px; overflow-y: auto; }
+.lr-row { margin: 8px 0; color: #e9e9ee; }
+.lr-error { margin-top: 8px; color: #ff6b6b; font-size: .9rem; }
 
 .btn-claim {
-  margin-top: .6rem; padding: .55rem .85rem; font-weight: 700;
-  border-radius: .5rem; border: 1px solid #7b2cff; background: #fff; color: #7b2cff;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #4ade80;
+  background: #1a1f1a;
+  color: #eaffea;
+  font-weight: 700;
+  cursor: pointer;
 }
-.btn-claim:disabled { opacity: .55; cursor: not-allowed; }
+.btn-claim:disabled { opacity: .6; cursor: not-allowed; }
 
-/* Jackpot theme support */
-body.freaky-mode .last-round__toggle { background: #250026; color: #f6d8ff; border-bottom-color: #3a003d; }
-body.freaky-mode .last-round { background: #130014; color: #f6eefe; border-color: #3a003d; }
-body.freaky-mode .btn-claim { border-color: #ff4db3; color: #ffb3e0; }
+.drawer-close {
+  position: absolute; top: 8px; left: 8px;
+  width: 32px; height: 32px; border-radius: 6px;
+  border: 1px solid rgba(255,255,255,.15);
+  background: transparent; color: #fff; font-size: 20px; line-height: 30px;
+}
+
+/* Pull tab — matches Rules pattern, placed on right */
+.drawer-tab {
+  position: fixed;
+  right: 12px; bottom: 120px;         /* above footer buttons & timer */
+  padding: 10px 14px;
+  border-radius: 999px;
+  border: 1px solid rgba(255,255,255,.15);
+  background: rgba(18,17,19,.75);
+  color: #fff; font-weight: 700;
+  backdrop-filter: blur(6px);
+  z-index: 61;                        /* above drawer */
+}
+.drawer-tab-right { /* reserved for future variants */ }
+
+/* Light theme safety (if any) */
+body:not(.freaky-mode) .drawer { background: #ffffff; color: #171717; }
+body:not(.freaky-mode) .lr-row { color: #202022; }
+body:not(.freaky-mode) .btn-claim { background: #f7fff7; color: #0d3b0d; border-color:#16a34a; }
+body:not(.freaky-mode) .drawer-close { color: #111; border-color: #e5e7eb; }
+body:not(.freaky-mode) .drawer-tab { background: rgba(255,255,255,.9); color: #111; border-color:#e5e7eb; }
+
+/* Ensure it never hides the in‑card countdown bar */
+#timerContainer { z-index: 30; }  /* timer stays visible over page, below tabs */
+
 
 /* ============== Dynamic Poster FX ============== */
 @keyframes condor-breathe {

--- a/index.html
+++ b/index.html
@@ -160,35 +160,30 @@
   <!-- Dim overlay -->
   <div id="ff-drawer-overlay" class="ff-drawer-overlay" aria-hidden="true"></div>
 
-  <!-- Last Round pull-out -->
-  <aside id="lastRoundPanel" class="last-round hidden" aria-live="polite">
-    <button id="lastRoundToggle" class="last-round__toggle" aria-expanded="false" aria-controls="lastRoundBody">
-      Last Round
-    </button>
-
-    <div id="lastRoundBody" class="last-round__body" hidden>
-      <div class="lr-row">
-        <span>Round:</span> <strong id="lrRound">—</strong>
-        <span class="lr-sep">•</span>
-        <span id="lrMode">—</span>
-      </div>
-      <div class="lr-row">
-        <span>Winner:</span> <code id="lrWinner">—</code>
-      </div>
-      <div class="lr-row">
-        <span>Prize:</span> <strong id="lrPrize">—</strong>
-        <span class="lr-sep">•</span>
-        <span>Refund:</span> <strong id="lrRefund">—</strong>
-      </div>
-
-      <button id="lrClaimBtn" class="btn-claim" hidden>💸 Claim refund</button>
-      <div id="lrMsg" class="lr-msg" hidden></div>
-    </div>
-  </aside>
-
   <div id="mmHintMount"></div>
   <button id="connectBtnBottom" class="btn connect-sticky" aria-label="Connect Wallet (mobile)">
     🔗 Connect Wallet
+  </button>
+
+  <!-- Last Round Pull-out -->
+  <aside id="lastRoundDrawer" class="drawer drawer-right" aria-hidden="true">
+    <button id="lastRoundClose" class="drawer-close" aria-label="Close">×</button>
+    <h3 class="drawer-title">Last Round</h3>
+
+    <div class="drawer-body">
+      <div class="lr-row">Round: <span id="lrRoundNo">—</span> • <span id="lrMode">—</span></div>
+      <div class="lr-row">Winner: <span id="lrWinner">—</span></div>
+      <div class="lr-row">Prize: <span id="lrPrize">—</span></div>
+      <div class="lr-row">Refund/player: <span id="lrRefund">—</span></div>
+
+      <button id="lrClaimBtn" class="btn-claim" style="display:none;">💸 Claim refund</button>
+      <div id="lrError" class="lr-error" style="display:none;"></div>
+    </div>
+  </aside>
+
+  <!-- Pull tab (like Rules), positioned right -->
+  <button id="lastRoundTab" class="drawer-tab drawer-tab-right" aria-controls="lastRoundDrawer">
+    Last&nbsp;Round
   </button>
 
   <!-- Rules Tab Trigger -->


### PR DESCRIPTION
## Summary
- convert last round panel to right-side drawer with pull tab
- style drawer with contrasting panel and tab, keep timer unobscured
- wire JS refresh and claim logic to new drawer elements

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68acc5d1d2a0832ba054213a008adf97